### PR TITLE
Simplify specification of scheduled and due dates/times

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,9 @@
 // [x] Automatically refresh submissions list after merge
 // [ ] Test do_grade_completion to see if patching works
 
-var TZ = 4; // local time zone offset from UTC
+let current_date = new Date();
+var TZ = current_date.getUTCHours() - current_date.getHours(); // local time zone offset from UTC
+  // should be 5 (EST) or 4 (EDT)
 
 function myFunction() {
   // The comment below will trigger authorization dialog (yes, even as a comment)

--- a/app.js
+++ b/app.js
@@ -253,7 +253,8 @@ function create_material_drive( course_id, title, topic_name, description, mater
 }
 
 function get_topic_id( course_id, topic_name ) {  // creates the topic if it doesn't exist
-  existing_topic = Classroom.Courses.Topics.list( course_id ).topic.filter( t => t.name == topic_name );
+  let topic_list = Classroom.Courses.Topics.list( course_id ).topic;
+  let existing_topic = topic_list ? topic_list.filter( t => t.name == topic_name ) : [];
   if ( existing_topic.length > 0 ) {
     topic_id = existing_topic[0].topicId;
   } else {
@@ -262,6 +263,17 @@ function get_topic_id( course_id, topic_name ) {  // creates the topic if it doe
   }
   return topic_id;
 }
+
+// function get_topic_id( course_id, topic_name ) {  // creates the topic if it doesn't exist
+//   existing_topic = Classroom.Courses.Topics.list( course_id ).topic.filter( t => t.name == topic_name );
+//   if ( existing_topic.length > 0 ) {
+//     topic_id = existing_topic[0].topicId;
+//   } else {
+//     response = Classroom.Courses.Topics.create( {name: topic_name }, course_id );
+//     topic_id = response.topicId;
+//   }
+//   return topic_id;
+// }
 
 function create_assignment( row ) {
   spec = spec_journal( row );
@@ -340,9 +352,13 @@ function merge_submissions( course_id, assignment_id, limit=undefined ) {  // re
 
   title = Classroom.Courses.CourseWork.get( course_id, assignment_id).title;
   var merge_doc = DocumentApp.create( `merge submissions for ${title}` );
-  var target = merge_doc.getBody();
-
+  var merge_doc_id = merge_doc.getId();
+  merge_doc.saveAndClose();
+  
   for ( let submission of submissions ) {
+    var merge_doc = DocumentApp.openById( merge_doc_id );
+    var target = merge_doc.getBody();
+
     var file = DriveApp.getFileById( submission.fileId );
     if( file.getMimeType() == MimeType.GOOGLE_DOCS ) {
       var doc = DocumentApp.openById( submission.fileId );
@@ -368,6 +384,7 @@ function merge_submissions( course_id, assignment_id, limit=undefined ) {  // re
       warning = '\n>>>>> Source file is not a Google Doc; could not copy content. <<<<<\n'
       target.appendParagraph( warning );
     }
+    merge_doc.saveAndClose();
   }
   return merge_doc.getUrl();
 }

--- a/app.js
+++ b/app.js
@@ -323,26 +323,25 @@ function format_sch_datetime( sch_year, sch_month, sch_day, sch_hour, sch_min ) 
   return sch_datetime.toISOString();  
 }
 
-function format_due_date( due_year, due_month, due_day, due_hour, due_min ) {  // returns { year: , month: , day: }
-  due_datetime = new Date( due_year, due_month - 1, due_day, due_hour + TZ, due_min );
+function format_due_date( due_year, due_month, due_day, due_hour, due_min = 0 ) {  // returns { year: , month: , day: }
+  var due_datetime = new Date( due_year, due_month - 1, due_day, due_hour, due_min );
   if ( due_year && due_month && due_day ) {
-    due_date = {year: due_datetime.getFullYear(), month: due_datetime.getMonth() + 1, day: due_datetime.getDate()};
+    due_date = {year: due_datetime.getUTCFullYear(), month: due_datetime.getUTCMonth() + 1, day: due_datetime.getUTCDate()};
   } else {  // in case due date is blank
     due_date = undefined;
   }
   return due_date;
 }
 
-function format_due_time( due_year, due_month, due_day, due_hour, due_min ) {  // returns { hours: , minutes: }
-  due_datetime = new Date( due_year, due_month - 1, due_day, due_hour + TZ, due_min );
+function format_due_time( due_year, due_month, due_day, due_hour, due_min = 0 ) {  // returns { hours: , minutes: } in UTC
+  var due_datetime = new Date( due_year, due_month - 1, due_day, due_hour, due_min );
   if ( due_year && due_month && due_day ) {
-    due_time = { hours: due_datetime.getHours(), minutes: due_datetime.getMinutes() };
+    due_time = { hours: due_datetime.getUTCHours(), minutes: due_datetime.getUTCMinutes() };
   } else {  // in case due date is blank
     due_time = undefined;   
   }
   return due_time;
 }
-
 
 // DOCUMENT MANIPULATION FUNCTIONS
 

--- a/app.js
+++ b/app.js
@@ -5,13 +5,12 @@
 // [ ] Generate a report about student completion/grades on assignments
 // [x] Named sheets are refreshed not deleted + created, with option to delete
 // [x] Allow to set name of sheet in sheet-factory functions
-// [ ] Generalize some functions to library
-// [ ] Record some tricks for object manipulation into Quiver
+// [x] Generalize some functions to library
+// [x] Record some tricks for object manipulation into Quiver
 // [x] Source control
 // [x] copy_content embeds url to the file in the title
 // [x] Refresh submissions list
 // [x] Automatically refresh submissions list after merge
-// [ ] Test do_grade_completion to see if patching works
 
 function myFunction() {
   // The comment below will trigger authorization dialog (yes, even as a comment)

--- a/app.js
+++ b/app.js
@@ -13,10 +13,6 @@
 // [x] Automatically refresh submissions list after merge
 // [ ] Test do_grade_completion to see if patching works
 
-let current_date = new Date();
-var TZ = current_date.getUTCHours() - current_date.getHours(); // local time zone offset from UTC
-  // should be 5 (EST) or 4 (EDT)
-
 function myFunction() {
   // The comment below will trigger authorization dialog (yes, even as a comment)
   // ref: https://stackoverflow.com/questions/42796630/
@@ -480,10 +476,9 @@ function list_assignments_all( course_id ) {
   // returns array of { id:, title:, state:, topicId:, description:, materials:, maxPoints: }
   var response = Classroom.Courses.CourseWork.list( course_id, { courseWorkStates: ['DRAFT', 'PUBLISHED'] } );
   var assignments = response.courseWork.map( a => {
-    let refdate = new Date(1899,11,30,-1 + TZ);  // Google doesn't use Unix epoch time for timestamps
-    let datetime = a.dueDate ? 
-      new Date( a.dueDate.year, a.dueDate.month - 1, a.dueDate.day, a.dueTime.hours, 0 ) : undefined;
-    let date =  datetime ? (datetime - refdate) / 86400000 : undefined;
+    let d = a.dueDate ?
+      new Date( Date.UTC(a.dueDate.year, a.dueDate.month - 1, a.dueDate.day, a.dueTime.hours, 0) ) : undefined;
+    let date = d ? `${d.toString().slice(0,3)} ${d.toISOString().slice(0,10)} ${d.toTimeString().slice(0,5)}` : undefined;
     return Object.assign( a, { due: date } );
   });
   desired_keys = [ 


### PR DESCRIPTION
## What?
I updated the function `spec_journal` which takes a row from the "batch" sheet and uses the data in it to construct an appropriate object to represent an assignment, that the Classroom API needs to create new assignments. Formerly the function would expect the assignment's scheduled year, month, date, and hour as separate properties. Now it expects a JavaScript Date object for the scheduled date, and another for the scheduled time. Same goes for the assignment's due date and time.

## Why?
When the assignment dates were specified with integers in separate year, month, date, hour columns, it was not human-friendly to read, and date arithmetic in the spreadsheet was very difficult and error-prone. It turns out that you can format a cell in Sheets as a date or time, which is more human-friendly and this makes it easier to check that assignments are scheduled and due in a way that matches your calendar. It also allows the user to use simple date arithmetic with formulas to replicate assignments for the next year on the same weekly schedule.

## How?
If you format a cell as a date or time, the Sheets API will read it in as a Javascript Date object, conveniently evaluated against local time zone. I merge the time into the date using `setHours()` and `setMinutes()`. Then I use the functions `format_sch_datetime`, `format_due_date`, `format_due_time` to convert this into the objects required by the Classroom API.

## Anything else?
This script is designed to work as a container-bound script inside the spreadsheet [Classroom automation v1.5](https://docs.google.com/spreadsheets/d/1HyHGq3tTXFmBrAk0WuttPxFN3dPZM_xbY6i2RgedSdI/), which serves as the user interface. Therefore I had to add columns in the sheet "batch" to match what `spec_journal` expects:
- sch_date
- sch_time
- due_date
- due_time